### PR TITLE
Quick patch to allow starting from an index

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -2,7 +2,9 @@ import pandas as pd
 import lxml.html
 import os, sys
 import requests
+import itertools
 
+START_IDX = 0
 
 xlsx = 'Free+English+textbooks.xlsx'
 xfile = pd.ExcelFile(xlsx)
@@ -124,7 +126,7 @@ class Book:
 
 
 
-for idx, row in df.iterrows():
+for idx, row in itertools.islice(df.iterrows(), START_IDX, None):
     book = Book(idx, 
                 df['Book Title'].iloc[idx], 
                 df['Edition'].iloc[idx], 


### PR DESCRIPTION
Workaround to allow downloading book from start index (change START_IDX in scraper.py file)
Will allow users to continue scraper after network disconnect, and not start over